### PR TITLE
Add deployment pipeline

### DIFF
--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -1,0 +1,98 @@
+name: Build and Deploy to GKE
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT }}
+  GKE_CLUSTER: timeoff-mgmt-cluster
+  GKE_REGION: us-central1
+  GKE_ZONE: us-central1-a
+  DEPLOYMENT_NAME: timeoff-mgmt-deploy
+  IMAGE: timeoff-mgmt-image
+  CHART_NAME: timeoff-mgmt-chart
+  REPO_NAME: timeoff-mgmt-repo
+  NAMESPACE: timeoff-mgmt-dev
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish, and Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Setup gcloud CLI
+      - uses: google-github-actions/setup-gcloud@94337306dda8180d967a56932ceb4ddcf01edae7
+        with:
+          service_account_key: ${{ secrets.GKE_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT }}
+
+      - name: Setup Terraform
+          uses: hashicorp/setup-terraform@v1
+          with:
+            terraform_version: 0.14
+
+      - name: Apply Terraform
+          env:
+            GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_DEPLOY_SA }}
+          run: |
+            cd ../../terraform/dev/
+            terraform init -backend-config=backend.tf
+            terraform apply -auto-approve
+
+      # Configure Docker to use the gcloud command-line tool as a credential
+      # helper for authentication
+      - run: |-
+          gcloud --quiet auth configure-docker
+
+      # Get the GKE credentials so we can deploy to the cluster
+      - uses: google-github-actions/get-gke-credentials@fb08709ba27618c31c09e014e1d8364b02e5042e
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_ZONE }}
+          credentials: ${{ secrets.GCP_DEPLOY_SA }}
+
+      # Build the Docker image
+      - name: Build
+        run: |-
+          docker build \
+            --tag "$GKE_REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$IMAGE:$GITHUB_SHA" \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF"
+
+      # Push the Docker image to Google Container Registry
+      - name: Publish
+        run: |-
+          docker push "$GKE_REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$IMAGE:$GITHUB_SHA"
+
+      # Set up Helm
+      - name: Set up Helm
+          uses: helm/setup-helm@v1
+          with:
+            version: 3.11.0
+
+      # Create a new tag for the chart version
+      - name: Create Tag
+        run: |
+          git tag ${GITHUB_SHA} && git push --tags
+
+      # Package the chart
+      - name: Package Chart
+        run: |
+          helm package --version ${GITHUB_SHA} ../../k8s/timeoff-mgmt
+
+      # Publish the chart to the chart repo
+      - name: Publish Chart
+        run: |
+          helm push ${CHART_NAME}-${GITHUB_SHA}.tgz oci://$GKE_REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME
+
+      # Deploy the chart to the GKE cluster
+      - name: Deploy to GKE
+        run: |
+          helm upgrade ${DEPLOYMENT_NAME} ${CHART_NAME}-${GITHUB_SHA}.tgz --install --wait --namespace ${NAMESPACE} \
+          --set image.tag=$GITHUB_SHA,image.repository=$GKE_REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/$IMAGE

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 *.swm
 node_modules/
 *.sqlite
+.idea/
+.terraform.lock.hcl
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,28 @@
 # =============
 # 1. Create an empty directory and copy this file into it.
 #
-# 2. Create image with: 
+# 2. Create image with:
 #	docker build --tag timeoff:latest .
 #
-# 3. Run with: 
+# 3. Run with:
 #	docker run -d -p 3000:3000 --name alpine_timeoff timeoff
 #
-# 4. Login to running container (to update config (vi config/app.json): 
+# 4. Login to running container (to update config (vi config/app.json):
 #	docker exec -ti --user root alpine_timeoff /bin/sh
 # --------------------------------------------------------------------
-FROM alpine:latest as dependencies
+FROM node:14-alpine as dependencies
 
 RUN apk add --no-cache \
-    nodejs npm 
+    nodejs npm \
+    python3 \
+    make g++
+
+ENV PYTHON python3
 
 COPY package.json  .
-RUN npm install 
+RUN npm install
 
-FROM alpine:latest
+FROM node:14-alpine
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.docker.cmd="docker run -d -p 3000:3000 --name alpine_timeoff"

--- a/k8s/timeoff-mgmt/.helmignore
+++ b/k8s/timeoff-mgmt/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/timeoff-mgmt/Chart.yaml
+++ b/k8s/timeoff-mgmt/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: timeoff-mgmt
+version: 0.1.0
+description: A Helm chart for deploying a Node.js application on GKE
+maintainers:
+  - name: Juan Pablo Rivas
+    email: juanpablo.rivas@outlook.com
+appVersion: 1.0.0

--- a/k8s/timeoff-mgmt/templates/deployment.yaml
+++ b/k8s/timeoff-mgmt/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.deployment.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.deployment.name }}
+    spec:
+      containers:
+        - name: {{ .Values.deployment.name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          resources:
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}

--- a/k8s/timeoff-mgmt/templates/service.yaml
+++ b/k8s/timeoff-mgmt/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  labels:
+    app: {{ .Values.deployment.name }}
+spec:
+  ports:
+    - name: {{ .Values.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ .Values.deployment.name }}
+  type: ClusterIP

--- a/k8s/timeoff-mgmt/values.yaml
+++ b/k8s/timeoff-mgmt/values.yaml
@@ -1,0 +1,17 @@
+deployment:
+  name: timeoff-mgmt-deployment
+  replicas: 1
+image:
+  repository: us-central1-docker.pkg.dev/timeoff-mgmt/timeoff-mgmt-registry/timeoff-mgmt
+  tag: latest
+service:
+  port: 80
+  name: timeoff-mgmt-svc
+portName: http
+resources:
+  limits:
+    cpu: "100m"
+    memory: "256Mi"
+  requests:
+    cpu: "100m"
+    memory: "256Mi"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1474,9 +1474,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         }
       }
     },
@@ -1774,9 +1774,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         }
       }
     },
@@ -1806,9 +1806,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "dev": true
         }
       }
@@ -2039,16 +2039,16 @@
           },
           "dependencies": {
             "graceful-fs": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-              "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+              "version": "4.2.10",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+              "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
             }
           }
         },
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "inherits": {
           "version": "1.0.2",
@@ -2082,14 +2082,6 @@
       "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
       "requires": {
         "sparkles": "^1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
-      "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
-      "requires": {
-        "natives": "^1.1.3"
       }
     },
     "growl": {
@@ -2771,9 +2763,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "optional": true
         }
       }
@@ -2815,9 +2807,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "optional": true
         }
       }
@@ -3253,9 +3245,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "strip-bom": {
           "version": "2.0.0",
@@ -4034,11 +4026,6 @@
         }
       }
     },
-    "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
-    },
     "nconf": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.8.5.tgz",
@@ -4129,9 +4116,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
           "dev": true
         },
         "nopt": {
@@ -4761,9 +4748,9 @@
       },
       "dependencies": {
         "graceful-fs": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         }
       }
     },
@@ -6497,6 +6484,11 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "isarray": {
           "version": "0.0.1",

--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket  = "timeoff-mgmt-tf-state-bucket"
+    prefix  = "dev/terraform.tfstate"
+  }
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,0 +1,49 @@
+# Create VPC
+resource "google_compute_network" "vpc" {
+  name                    = "${var.project_id}-vpc"
+  auto_create_subnetworks = "false"
+}
+
+# Create Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name          = "${var.project_id}-subnet"
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = "10.10.0.0/24"
+}
+
+# Create GKE cluster (with a separately managed node pool)
+resource "google_container_cluster" "cluster" {
+  name     = var.cluster_name
+  location = var.region
+  remove_default_node_pool = true
+  initial_node_count = var.node_count
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
+}
+
+resource "google_container_node_pool" "pool" {
+  name = var.pool_name
+  location   = var.region
+  cluster = google_container_cluster.cluster.name
+  node_count = var.node_count
+
+  node_config {
+    preemptible  = true # Since this is a dev env, we are using preemp machines to reduce costs.
+    machine_type = "e2-micro"
+
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    # service_account = google_service_account.default.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
+}
+
+# Create registry to store images/other artifacts
+resource "google_artifact_registry_repository" "registry-repo" {
+  location      = var.region
+  repository_id = var.registry_name
+  format        = "DOCKER"
+}

--- a/terraform/dev/provider.tf
+++ b/terraform/dev/provider.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/dev/terraform.tfvars
+++ b/terraform/dev/terraform.tfvars
@@ -1,0 +1,9 @@
+project_id = "timeoff-mgmt"
+region = "us-central1"
+cluster_name = "timeoff-mgmt-cluster"
+pool_name = "timeoff-mgmt-pool"
+node_count = 1
+registry_name = "timeoff-mgmt-registry"
+port_name = "http"
+port = 80
+machine_type = "e2-micro"

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,0 +1,35 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "pool_name" {
+  type = string
+}
+
+variable "node_count" {
+  type = number
+}
+
+variable "registry_name" {
+  type = string
+}
+
+variable "port_name" {
+  type = string
+}
+
+variable "port" {
+  type = number
+}
+
+variable "machine_type" {
+  type = string
+}


### PR DESCRIPTION
This change introduces a GitHub Action workflow that enables continuous deployment of a Node.js app to GKE using Terraform and Helm. The workflow is triggered by pushes to the main branch and performs the following steps:

- Checkout the code from the repository
- Setup the gcloud CLI and authenticate using a service account key stored as a GitHub secret
- Setup Terraform and apply the the `main.tf`onfiguration located in `terraform/dev`. This provisions the necessary resources for the application deployment pipeline, such as a GKE cluster, an Artifact Registry repo and a GCS bucket for TF state management.
- Authenticate Docker to use the gcloud CLI as a credential helper
- Get the credentials for the GKE cluster.
- Build a Docker image for the application and tag it with the commit SHA.
- Push the Docker image to the GCP Artifact Registry.
- Setup Helm and package the Helm chart located in `k8s/` using the commit SHA as the chart version.
- Publish the chart to GCP Artifact Registry(Used as chart repo as well).
- Deploy the chart to the GKE cluster using Helm, specifying the image tag and namespace.

This workflow allows for automated and reliable deployment of the infrastructure and application on GKE, and can be easily adapted for use in other environments/clouds.
